### PR TITLE
improve html support

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "sitecore-scriban",
 	"displayName": "Sitecore Scriban",
 	"description": "Scriban Templates syntax coloring and auto completion for Sitecore Experience Accelerator (SXA)",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"publisher": "adamnaj",
 	"repository": {
 		"type": "git",
@@ -37,6 +37,12 @@
 					".scriban"
 				],
 				"configuration": "./language-configuration.json"
+			},
+			{
+				"id": "html",
+				"extensions": [
+					".scriban"
+				]
 			}
 		],
 		"grammars": [


### PR DESCRIPTION
Hi,

First of all thanks for writing this great extension. It really makes developing with .Scriban files a lot easier!

However, we are using custom created webcomponents now with scriban files, and I noticed I was not getting any intellisense on these components in .scriban files. The same applies for standard elements like a div.

With adding this extra bit of configuration in the package.json it gives us useful codehints on custom elements as well as standard html.

Example custom element:
![image](https://user-images.githubusercontent.com/5425589/105343817-6890f900-5be2-11eb-90b8-4b7ebe167272.png)

Example standard html element:
![image](https://user-images.githubusercontent.com/5425589/105343865-7ba3c900-5be2-11eb-8564-a77f22110f86.png)
